### PR TITLE
Change iteritems() into items() to make tests succeed in Python 2.6.7, 3.3.1 and 3.4.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 python:
   - "pypy"
-  - "pypy3"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 python:
   - "pypy"
+  - "pypy3"
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 install:
-    - python setup.py -q install
+  - "pip install -r requirements.txt"
 script:
-    - py.test --tb=native seep
-    - python -m doctest README.rst
+  - py.test --tb=native seep
+  - python -m doctest README.rst

--- a/seep/core.py
+++ b/seep/core.py
@@ -2,7 +2,7 @@ import jsonschema.validators
 
 
 def _set_defaults(validator, properties, instance, schema):
-    for property, subschema in properties.iteritems():
+    for property, subschema in properties.items():
         if "default" in subschema and property not in instance:
             instance[property] = subschema["default"]
 
@@ -59,7 +59,7 @@ def _properties_with_defaults(validator_cls):
             subschemas.extend(
                 (subinstance.setdefault(property, {}), subsubschema)
                 for property, subsubschema in
-                subschema.get("properties", {}).iteritems()
+                subschema.get("properties", {}).items()
             )
 
     return properties_with_defaults


### PR DESCRIPTION
Hi,
I believe the slight performance penalty of copying instead of getting an iterator in 2.6.7 is acceptable compared to getting Python 3.x compatibility.